### PR TITLE
#93: Fixed an issue that resulted in comparisons using the iCompare i…

### DIFF
--- a/Libraries/SQLDevice/Source/SQLOperators.cs
+++ b/Libraries/SQLDevice/Source/SQLOperators.cs
@@ -1516,9 +1516,19 @@ namespace Alphora.Dataphor.DAE.Device.SQL
 								localDevicePlan.Device.TranslateExpression(localDevicePlan, planNode.Nodes[1], false)
 							),
 							new ValueExpression(-1)
-						)
+						),
+						new CaseItemExpression
+						(
+							new BinaryExpression
+							(
+								localDevicePlan.Device.TranslateExpression(localDevicePlan, planNode.Nodes[0], false),
+								"iGreater",
+								localDevicePlan.Device.TranslateExpression(localDevicePlan, planNode.Nodes[1], false)
+							),
+							new ValueExpression(1)
+						),
 					},
-					new CaseElseExpression(new ValueExpression(1))
+					new CaseElseExpression(new ValueExpression(null, TokenType.Nil))
 				);
 		}
 	}


### PR DESCRIPTION
…nstruction mapped to an SQL device incorrectly including results with null for the target of the comparison.