### PR TITLE
Fixed a compiler issue that ignored rename of multiple columns. The c…

### DIFF
--- a/Dataphor/DAE/Compiling/CompilerException.cs
+++ b/Dataphor/DAE/Compiling/CompilerException.cs
@@ -596,8 +596,11 @@ namespace Alphora.Dataphor.DAE.Compiling
 			/// <summary>Error code 105287: "Custom message may only reference global table variables for database-wide and transition constraints."</summary>
 			NonRemotableCustomConstraintMessage = 105287,
 
-			/// <summary>Error code 105388: "Conveyor for type "{0}" is ambiguous between "{1}" and "{2}"."</summary>
+			/// <summary>Error code 105288: "Conveyor for type "{0}" is ambiguous between "{1}" and "{2}"."</summary>
 			AmbiguousConveyor = 105288,
+
+			/// <summary>Error code 105289: "Column "{0}" has already been renamed."</summary>
+			DuplicateRenameColumn = 105289
 		}
 		
 		// Resource manager for this exception class

--- a/Dataphor/DAE/Compiling/CompilerException.resx
+++ b/Dataphor/DAE/Compiling/CompilerException.resx
@@ -682,4 +682,7 @@
   <data name="105288" xml:space="preserve">
     <value>Conveyor for type "{0}" is ambiguous between "{1}" and "{2}".</value>
   </data>
+  <data name="105289" xml:space="preserve">
+    <value>Column "{0}" has already been renamed.</value>
+  </data>
 </root>

--- a/Dataphor/DAE/Runtime.Instructions/RenameNode.cs
+++ b/Dataphor/DAE/Runtime.Instructions/RenameNode.cs
@@ -120,12 +120,14 @@ namespace Alphora.Dataphor.DAE.Runtime.Instructions
 							throw new Schema.SchemaException(Schema.SchemaException.Codes.ObjectNotFound, renameColumn.ColumnName);
 						else if (renameColumnIndex == index)
 						{
+							if (columnAdded)
+								throw new CompilerException(CompilerException.Codes.DuplicateRenameColumn, renameColumn.ColumnName);
+
 							column = SourceTableVar.Columns[index].InheritAndRename(renameColumn.ColumnAlias);
 							column.MergeMetaData(renameColumn.MetaData);
 							DataType.Columns.Add(column.Column);
 							TableVar.Columns.Add(column);
 							columnAdded = true;
-							break;
 						}
 					}
 					if (!columnAdded)

--- a/Dataphor/DAE/Runtime.Instructions/RowNodes.cs
+++ b/Dataphor/DAE/Runtime.Instructions/RowNodes.cs
@@ -599,10 +599,12 @@ namespace Alphora.Dataphor.DAE.Runtime.Instructions
 							throw new Schema.SchemaException(Schema.SchemaException.Codes.ObjectNotFound, renameColumn.ColumnName);
 						else if (renameColumnIndex == index)
 						{
+							if (columnAdded)
+								throw new CompilerException(CompilerException.Codes.DuplicateRenameColumn, renameColumn.ColumnName);
+
 							column = new Schema.Column(renameColumn.ColumnAlias, SourceRowType.Columns[index].DataType);
 							DataType.Columns.Add(column);
 							columnAdded = true;
-							break;
 						}
 					}
 					if (!columnAdded)


### PR DESCRIPTION
…ompiler will now correctly throw if an attempt is made to rename the same column multiple times in a row or table rename expression.