### PR TITLE
Addressed issue with invalid translation of SQLQuery(). 

### DIFF
--- a/Dataphor/DAE/Runtime.Instructions/PlanNode.cs
+++ b/Dataphor/DAE/Runtime.Instructions/PlanNode.cs
@@ -326,12 +326,13 @@ namespace Alphora.Dataphor.DAE.Runtime.Instructions
 			{
 				for (int index = 0; index < _nodes.Count; index++)
 				{
-					_nodes[index].DeterminePotentialDevice(plan);
+					var node = _nodes[index];
+					node.DeterminePotentialDevice(plan);
 
-					NoDevice = NoDevice || _nodes[index].NoDevice;
+					NoDevice = NoDevice || node.NoDevice;
 					if (!NoDevice)
 					{
-						childDevice = _nodes[index].PotentialDevice;
+						childDevice = node.PotentialDevice;
 						if (childDevice != null)
 						{
 							if (currentChildDevice == null)

--- a/Dataphor/DAE/Runtime.Instructions/TableNodes.cs
+++ b/Dataphor/DAE/Runtime.Instructions/TableNodes.cs
@@ -1822,8 +1822,9 @@ namespace Alphora.Dataphor.DAE.Runtime.Instructions
 				_potentialDevice = ((Schema.BaseTableVar)_tableVar).Device;
 			else
 				throw new CompilerException(CompilerException.Codes.InvalidRetrieveTarget, plan.CurrentStatement());
+			NoDevice = !ShouldSupport || _potentialDevice == null;
 		}
-		
+
 		public override void DetermineDevice(Plan plan)
 		{
 			if (_potentialDevice != null)

--- a/Libraries/SQLDevice/Source/SQLDevice.cs
+++ b/Libraries/SQLDevice/Source/SQLDevice.cs
@@ -5313,6 +5313,11 @@ namespace Alphora.Dataphor.DAE.Device.SQL
 	// operator SQLQuery(const ADeviceName : System.Name, const AStatement : System.String, const AInValues : row, var AOutValues : row, const ATableType : String, const AKeyInfo : String) : table
     public class SQLQueryNode : TableNode
     {
+		public SQLQueryNode()
+		{
+			ShouldSupport = false;
+		}
+
 		public override void DetermineDataType(Plan plan)
 		{
 			DetermineModifiers(plan);


### PR DESCRIPTION
Not all table nodes are translatable just because they are associated with a device.