### PR TITLE
Repo Management:  Adds repo management templates

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,101 @@
+Contributing to Dataphor
+============================
+
+The Dataphor project operates an open contributor model where anyone is welcome to contribute towards development in the form of peer review, testing and patches. This document explains the practical process and guidelines for contributing.
+
+Firstly in terms of structure, there is no particular concept of “Core developers” in the sense of privileged people. Open source often naturally revolves around meritocracy where longer term contributors gain more trust from the developer community. However, some hierarchy is necessary for practical purposes. As such there are repository “maintainers” who are responsible for merging pull requests as well as a “lead maintainer” who is responsible for the release cycle, overall merging, moderation and appointment of maintainers.
+
+
+Contributor Workflow
+--------------------
+
+The codebase is maintained using the “contributor workflow” where everyone without exception contributes patch proposals using “pull requests”. This facilitates social contribution, easy testing and peer review.
+
+To contribute a patch, the workflow is as follows:
+
+  - Fork repository
+  - Create topic branch
+  - Commit patches
+
+The project coding conventions in [doc/developer-notes.md](doc/developer-notes.md) must be adhered to.
+
+In general [commits should be atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention) and diffs should be easy to read. For this reason do not mix any formatting fixes or code moves with actual code changes.
+
+Commit messages should be verbose by default consisting of a short subject line (50 chars max), a blank line and detailed explanatory text as separate paragraph(s); unless the title alone is self-explanatory (like "Corrected typo in main.cpp") then a single title line is sufficient. Commit messages should be helpful to people reading your code in the future, so explain the reasoning for your decisions. Further explanation [here](http://chris.beams.io/posts/git-commit/).
+
+If a particular commit references another issue, please add the reference, for example "refs #1234", or "fixes #4321". Using "fixes or closes" keywords will cause the corresponding issue to be closed when the pull request is merged.
+
+Please refer to the [Git manual](https://git-scm.com/doc) for more information about Git.
+
+  - Push changes to your fork
+  - Create pull request
+
+The title of the pull request should be prefixed by the component or area that the pull request affects. Examples:
+
+    Security: Implements PKI security
+    FHIR:  Adds conformance as specified by HL7 FHIR
+    Device: Adds Redis database device
+    Trivial: fix typo
+
+If a pull request is specifically not to be considered for merging (yet) please prefix the title with [WIP] or use [Tasks Lists](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments) in the body of the pull request to indicate tasks are pending.
+
+The body of the pull request should contain enough description about what the patch does together with any justification/reasoning. You should include references to any discussions (for example other tickets or mailing list discussions).
+
+At this stage one should expect comments and review from other contributors. You can add more commits to your pull request by committing them locally and pushing to your fork until you have satisfied all feedback. If your pull request is accepted for merging, you may be asked by a maintainer to squash and or rebase your commits before it will be merged. The length of time required for peer review is unpredictable and will vary from patch to patch.
+
+
+Pull Request Philosophy
+-----------------------
+
+Patchsets should always be focused. For example, a pull request could add a feature, fix a bug, or refactor code; but not a mixture. Please also avoid super pull requests which attempt to do too much, are overly large, or overly complex as this makes review difficult.
+
+
+###Features
+
+When adding a new feature, thought must be given to the long term technical debt and maintenance that feature may require after inclusion. Before proposing a new feature that will require maintenance, please consider if you are willing to maintain it (including bug fixing). If features get orphaned with no maintainer in the future, they may be removed by the Repository Maintainer.
+
+
+###Refactoring
+
+Refactoring is a necessary part of any software project's evolution. The following guidelines cover refactoring pull requests for the project.
+
+There are three categories of refactoring, code only moves, code style fixes, code refactoring. In general refactoring pull requests should not mix these three kinds of activity in order to make refactoring pull requests easy to review and uncontroversial. In all cases, refactoring PRs must not change the behaviour of code within the pull request (bugs must be preserved as is).
+
+Project maintainers aim for a quick turnaround on refactoring pull requests, so where possible keep them short, uncomplex and easy to verify. 
+
+
+"Decision Making" Process
+-------------------------
+Whether a pull request is merged into Dataphor rests with the project merge maintainers and ultimately the project lead. 
+
+Maintainers will take into consideration if a patch is in line with the general principles of the project; meets the minimum standards for inclusion; and will judge the general consensus of contributors.
+
+In general, all pull requests must:
+
+  - have a clear use case, fix a demonstrable bug or serve the greater good of the project (for example refactoring for modularisation);
+  - be well peer reviewed;
+  - have unit tests and functional tests where appropriate;
+  - follow code style guidelines;
+  - not break the existing test suite;
+  - where bugs are fixed, where possible, there should be unit tests demonstrating the bug and also proving the fix. This helps prevent regression.
+
+###Peer Review
+
+Anyone may participate in peer review which is expressed by comments in the pull request. Typically reviewers will review the code for obvious errors, as well as test out the patch set and opine on the technical merits of the patch. Project maintainers take into account the peer review when determining if there is consensus to merge a pull request (remember that discussions may have been spread out over github, mailing list and IRC discussions). The following language is used within pull-request comments:
+
+  - ACK means "I have tested the code and I agree it should be merged";
+  - NACK means "I disagree this should be merged", and must be accompanied by sound technical justification. NACKs without accompanying reasoning may be disregarded;
+  - utACK means "I have not tested the code, but I have reviewed it and it looks OK, I agree it can be merged";
+  - Concept ACK means "I agree in the general principle of this pull request";
+  - Nit refers to trivial, often non-blocking issues.
+
+Reviewers should include the commit hash which they reviewed in their comments.
+
+Project maintainers reserve the right to weigh the opinions of peer reviewers using common sense judgement and also may weight based on meritocracy: Those that have demonstrated a deeper commitment and understanding towards the project (over time) or have clear domain expertise may naturally have more weight, as one would expect in all walks of life.
+
+Where a patch set affects consensus critical code, the bar will be set much higher in terms of discussion and peer review requirements, keeping in mind that mistakes could be very costly to the wider community. This includes refactoring of consensus critical code.
+
+Release Policy
+--------------
+
+The project leader is the release manager for each Dataphor release.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,17 @@
+<!--- Remove sections that do not apply -->
+### Describe the issue
+
+### Steps to reproduce
+1. 
+2. 
+3. 
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Screenshots (if applicable)
+
+### What .NET platform/OS are you using (Windows, Linux Mono, Mac Mono)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!--- Remove sections that do not apply -->
+#### What is the purpose of this pull request (PR)?
+
+#### Any background context to help the reviewer?
+
+#### Was this PR tested and how?
+
+#### Does this PR resolve an open issue (reference issue #)?
+1. Fixes issue #
+
+#### More Questions:
+- Does the knowledge base or documentation need an update?
+- Does this PR add or change dependencies?


### PR DESCRIPTION
#### What is the purpose of this pull request (PR)?
Adds git repo management templates for pull requests, issues and contributing to the source.

#### Any background context to help the reviewer?
These templates are Github specific and some are relatively new functionality.  Github first implemented the PR and issue templates in February 2016.  The contributing template was added in ~2012.  Please let me know if you want me to make changes to the verbiage in any of the templates but from my experience, these templates are helpful tools for the repo maintainer.  The contributing template verbiage was forked from [Bitcoin] (https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md)

#### Was this PR tested and how?
Yes, on my forked repo and this uses the new pull request template.

#### Does this PR resolve an open issue (reference issue #)?
No.
#### More Questions:
- Does the knowledge base or documentation need an update? No.
- Does this PR add or change dependencies? No.