### PR TITLE
Update README.adoc - Remove dead links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,9 +14,9 @@ For more information, check out our http://dataphor.org[website].
 [[Documentation]]
 == Documentation
 
-* https://documentation.dataphor.com/UsersGuide/UsersGuide.html[Dataphor User's Guide]
-* https://documentation.dataphor.com/DevelopersGuide/DevelopersGuide.html[Dataphor Developer's Guide]
-* https://documentation.dataphor.com/DataphorReference/DataphorReference.html[Dataphor Reference]
+* https://documentation.dataphor.org/UsersGuide/UsersGuide.html[Dataphor User's Guide]
+* https://documentation.dataphor.org/DevelopersGuide/DevelopersGuide.html[Dataphor Developer's Guide]
+* https://documentation.dataphor.org/DataphorReference/DataphorReference.html[Dataphor Reference]
 
 == Installation
 


### PR DESCRIPTION
Links were dead when I tried to access the User's Guide.
It was ".com" rather than ".org".

Fixes the issue https://github.com/DBCG/Dataphor/issues/49